### PR TITLE
Enhance workflow automation and bump version to 0.2.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,11 +6,18 @@ on:
       - main
     tags:
       - 'v*'
+  workflow_run:
+    workflows: ["Test Build on PR"]
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
   publish:
     name: Publish Package
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
 
     permissions:
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-specment",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Interactive CLI tool for creating Docusaurus-based specification documentation projects",
   "type": "module",
   "author": "Plenarc",


### PR DESCRIPTION
- Add workflow_run trigger to publish.yaml to run after successful test builds
- Add conditional check in publish job to ensure tests pass before publishing
- Specify pull_request event types in test.yaml (opened, synchronize, reopened, ready_for_review)
- Bump package version from 0.2.0 to 0.2.1
- Improve CI/CD reliability by preventing premature package publication without passing tests