### PR TITLE
ci: Remove redundant push trigger and bump version to 0.2.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-specment",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Interactive CLI tool for creating Docusaurus-based specification documentation projects",
   "type": "module",
   "author": "Plenarc",


### PR DESCRIPTION
- Remove duplicate push trigger from test workflow (pull_request already covers main branch)
- Simplify CI/CD pipeline by consolidating workflow triggers
- Bump package version from 0.2.1 to 0.2.2
- Reduce unnecessary workflow executions on push events