### PR TITLE
ci: Migrate to OIDC trusted publishing and bump version to 0.2.6

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,21 +41,13 @@ jobs:
 
       - name: Check npm authentication
         run: |
-          echo "Checking npm authentication..."
-          npm whoami
-          echo "Current registry:"
-          npm config get registry
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          echo "Using Trusted Publishing (OIDC)"
+          echo "Registry URL: $(npm config get registry)"
 
-      - name: Check package info
+      - name: Check package ownership
         run: |
-          echo "Package name: $(npm pkg get name)"
-          echo "Package version: $(npm pkg get version)"
-          echo "Checking if package exists..."
-          npm view create-specment || echo "Package does not exist (expected for first publish)"
+          echo "Checking package ownership..."
+          npm owner ls create-specment || echo "Package does not exist or no access"
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-specment",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Interactive CLI tool for creating Docusaurus-based specification documentation projects",
   "type": "module",
   "author": "Plenarc",


### PR DESCRIPTION
- Replace NPM_TOKEN environment variable with OIDC trusted publishing
- Simplify npm authentication check to display registry URL only
- Update package ownership verification step with improved error handling
- Remove NODE_AUTH_TOKEN from publish step (handled by OIDC)
- Bump package version from 0.2.5 to 0.2.6
- Enhance security by using GitHub's native OIDC provider instead of static tokens