### PR TITLE
ci: Simplify npm publish workflow and add npmrc configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,15 +39,5 @@ jobs:
       - name: Build project
         run: pnpm run build
 
-      - name: Check npm authentication
-        run: |
-          echo "Using Trusted Publishing (OIDC)"
-          echo "Registry URL: $(npm config get registry)"
-
-      - name: Check package ownership
-        run: |
-          echo "Checking package ownership..."
-          npm owner ls create-specment || echo "Package does not exist or no access"
-
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,16 @@
+# npm configuration for docusaurus-theme-plantuml
+# Removed deprecated settings: verify-deps-before-run and _jsr-registry
+
+# Use pnpm as package manager
+package-manager=pnpm
+
+# Registry configuration
+registry=https://registry.npmjs.org/
+
+# Security settings
+audit-level=moderate
+fund=false
+
+# Performance settings
+prefer-offline=true
+cache-max=86400000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-specment",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Interactive CLI tool for creating Docusaurus-based specification documentation projects",
   "type": "module",
   "author": "Plenarc",


### PR DESCRIPTION
- Remove redundant npm authentication and package ownership checks from publish workflow
- Simplify publish command by removing --access and --provenance flags
- Add .npmrc configuration file with registry, security, and performance settings
- Configure pnpm as the package manager in npmrc
- Set audit-level to moderate and enable offline-first caching for improved reliability
- Streamline CI/CD pipeline by delegating authentication to OIDC trusted publishing