### PR TITLE
ci: Update Node.js version and streamline build scripts

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,8 +22,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Check npm version
+        run: |
+          echo "npm version: $(npm --version)"
+          echo "Node.js version: $(node --version)"
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-specment",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Interactive CLI tool for creating Docusaurus-based specification documentation projects",
   "type": "module",
   "author": "Plenarc",
@@ -28,7 +28,6 @@
     "url": "https://github.com/plenarc/create-specment/issues"
   },
   "scripts": {
-    "prebuild": "nr format && nr lint:fix",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest --run",
@@ -37,8 +36,7 @@
     "format": "biome format . --write",
     "lint": "biome lint . --diagnostic-level=error",
     "lint:fix": "biome lint . --fix",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "nr build && nr test"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@antfu/ni": "^28.0.0",


### PR DESCRIPTION
- Upgrade Node.js version from 22 to 24 in publish workflow
- Add npm and Node.js version logging step for better debugging
- Remove prebuild script to simplify build process
- Remove prepublishOnly script to streamline publishing workflow
- Bump version to 0.2.8 in package.json
- Reduce build script complexity and improve CI/CD efficiency